### PR TITLE
Update kaltura-admin.js

### DIFF
--- a/js/kaltura-admin.js
+++ b/js/kaltura-admin.js
@@ -166,6 +166,10 @@
 		$(document.body).on('click', '#kaltura-media-button', function (event) {
 			var defaultScreen = $(this).data('default-screen');
 			var state;
+			
+			// workaround to ensure main WP editor in text mode so embed code can be inserted Jira DLEMBC-90
+			$('#content-html').trigger('click');
+			
 			if (defaultScreen == 'browse')
 				state = 'iframe:kaltura_browse';
 			else


### PR DESCRIPTION
Video's from Kaltura browser were failing to write embed code back to main WP editor window. For some reason this is due to it being in visual mode as embed code is inserted ok in text editor mode, therefore workaround to toggle it after Kaltura media icon clicked